### PR TITLE
调整actions让actions可以Build出可在PROD应用的Jar文件

### DIFF
--- a/.github/workflows/PROD OK Build.yml
+++ b/.github/workflows/PROD OK Build.yml
@@ -1,0 +1,48 @@
+name: PROD OK Build
+
+on:
+
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  build:
+
+    name: Jar Build
+    
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v1.0.3
+        
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Build with Gradle
+        run: ./gradlew buildPlugin
+        
+      # Upload File
+      - name: Upload Jar File
+        uses: actions/upload-artifact@v2
+        with: 
+          name: Jar File
+          path: build/mirai
+      
+      - name: Upload All Build File
+        uses: actions/upload-artifact@v2
+        with: 
+          name: All File
+          path: build


### PR DESCRIPTION
要与CI分开
可以直接作为beta版本的下载链接，且方便在没有电脑时使用github web来打包。
最重要的是，这玩意不需要自己去整令人头疼的环境，gradle太可怕了
Allow edits and access to secrets by maintainers