### PR TITLE
修复一些bug，支持DYNAMIC_TYPE_PGC_UNION类型的番剧订阅，drawSmallCard支持动态封面高度

### DIFF
--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/BascLink.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/BascLink.kt
@@ -46,7 +46,7 @@ fun MUSIC_LINK(id: String) = "$BASE_MUSIC/au$id"
 fun MEDIA_LINK(id: String) = "$BASE_PGC_MEDIA/md$id"
 fun SEASON_LINK(id: String) = if (toShortLink) "$BASE_SHORT/ss$id" else "$BASE_PGC/ss$id"
 fun EPISODE_LINK(id: String) = if (toShortLink) "$BASE_SHORT/ep$id" else "$BASE_PGC/ep$id"
-fun PGC_LINK(id: String) = if (toShortLink) "$BASE_SHORT/$id" else "$BASE_PGC/$id"
+fun PGC_LINK(id: String) = if (toShortLink) "$BASE_SHORT/$id" else if (id.startsWith("md")) "$BASE_PGC_MEDIA/$id" else "$BASE_PGC/$id"
 suspend fun LIVE_LINK(id: String) = if (toShortLink) {
     biliClient.liveShortLink(id).run {
         this?.removePrefix("https://") ?: "$BASE_LIVE/$id"

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Dynamic.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Dynamic.kt
@@ -442,8 +442,8 @@ data class ModuleDynamic(
             val mid: Long,
             @SerialName("state")
             val state: Int,
-            @SerialName("is_upower_active")
-            val active: Boolean? = null,
+            //@SerialName("is_upower_active")
+            //val active: Boolean? = null,
             @SerialName("desc")
             val desc: Desc,
             @SerialName("button")

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Dynamic.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Dynamic.kt
@@ -46,6 +46,7 @@ enum class DynamicType(val text: String) {
     DYNAMIC_TYPE_LIVE("直播"),
     DYNAMIC_TYPE_LIVE_RCMD("直播"),
     DYNAMIC_TYPE_PGC("番剧"),
+    DYNAMIC_TYPE_PGC_UNION("番剧"),
     DYNAMIC_TYPE_COMMON_SQUARE("动态"),
     DYNAMIC_TYPE_COMMON_VERTICAL("动态"),
     DYNAMIC_TYPE_UGC_SEASON("合集"),

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Live.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/Live.kt
@@ -108,7 +108,7 @@ data class LiveRoomDetail(
     @SerialName("new_pendants")
     val newPendants: NewPendants? = null,
     @SerialName("up_session")
-    val upSession: Long? = null,
+    val upSession: String? = null,
     @SerialName("pk_status")
     val pkStatus: Int? = null,
     @SerialName("pk_id")

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicMajorDraw.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicMajorDraw.kt
@@ -381,6 +381,22 @@ suspend fun drawSmallCard(
     rbadge: String,
     duration: String?
 ): Image {
+    // 1) 先把需要的图片下载好，拿到它的实际宽高
+    //    这里让封面宽度固定为 cardContentRect.width * 0.4f
+    val desiredCoverWidth = cardContentRect.width * 0.4f
+    val fallbackUrl = imgApi(cover, desiredCoverWidth.toInt(), 100 /* 高度先随便写一个，不太影响 */)
+    val coverImg = getOrDownloadImageDefault(cover, fallbackUrl, CacheType.IMAGES)
+
+    // 2) 根据图片原始宽高和想要的 cover 显示宽度，计算出它等比缩放后的显示高度
+    val originWidth = coverImg.width.toFloat()
+    val originHeight = coverImg.height.toFloat()
+
+    // 目标是“指定封面宽度 = desiredCoverWidth，然后让高度跟着图片宽高比变动”
+    val scale = desiredCoverWidth / originWidth
+    val scaledCoverHeight = originHeight * scale
+
+    // 3) 接下来根据 title/desc 段落高度、徽章高度等，计算出最终卡片整体高度
+    //    依然要做段落排版，但要先知道可用文本区域有多少宽度
     val paragraphStyle = ParagraphStyle().apply {
         maxLinesCount = 2
         ellipsis = "..."
@@ -388,95 +404,116 @@ suspend fun drawSmallCard(
         textStyle = titleTextStyle
     }
 
-    val coverWidth = quality.smallCardHeight * 1.6f  // 封面比例 16:10
-    val paragraphWidth = cardContentRect.width - quality.cardPadding - coverWidth
-
-    val titleParagraph = ParagraphBuilder(paragraphStyle, FontUtils.fonts).addText(title).build().layout(paragraphWidth)
-
+    // 假设卡片的总宽度仍是 cardRect.width，不变
+    val textAreaWidth = cardContentRect.width - quality.cardPadding - desiredCoverWidth
+    val titleParagraph = ParagraphBuilder(paragraphStyle, FontUtils.fonts)
+        .addText(title)
+        .build()
+        .layout(textAreaWidth)
+    
     paragraphStyle.apply {
         maxLinesCount = if (titleParagraph.lineNumber == 1) 3 else 2
         textStyle = descTextStyle
     }
+    val descParagraph = ParagraphBuilder(paragraphStyle, FontUtils.fonts)
+        .addText(desc ?: "")
+        .build()
+        .layout(textAreaWidth)
+    
+    // 计算出卡片最终高度：上面徽章区域(quality.badgeHeight) + coverHeight + 下方留白等
+    val cardHeight = 
+        quality.badgeHeight + 
+        scaledCoverHeight + 
+        quality.cardPadding // 视需求再加额外空隙
 
-    val descParagraph = ParagraphBuilder(paragraphStyle, FontUtils.fonts).addText(desc?:"").build().layout(paragraphWidth)
-
-    val videoCardRect = RRect.makeComplexXYWH(
-        quality.cardPadding.toFloat(),
-        quality.badgeHeight + 1f,
-        cardContentRect.width,
-        quality.smallCardHeight.toFloat(),
-        cardBadgeArc
-    )
-
+    // 4) 创建最终画布 (Surface)
     return Surface.makeRasterN32Premul(
         cardRect.width.toInt(),
-        quality.smallCardHeight + quality.badgeHeight + quality.cardPadding
+        cardHeight.toInt()
     ).apply {
-        canvas.apply {
+        val canvas = this.canvas
 
-            // 绘制卡片背景
-            drawCard(videoCardRect)
-            // 卡片阴影
-            drawRectShadowAntiAlias(videoCardRect.inflate(1f), theme.smallCardShadow)
+        // 4.1) 先根据新的 cardHeight 绘制背景、阴影等
+        val videoCardRect = RRect.makeComplexXYWH(
+            quality.cardPadding.toFloat(),
+            quality.badgeHeight + 1f,
+            cardContentRect.width,
+            cardHeight - (quality.badgeHeight + quality.cardPadding),
+            cardBadgeArc
+        )
+        canvas.drawCard(videoCardRect)
+        canvas.drawRectShadowAntiAlias(
+            videoCardRect.inflate(1f),
+            theme.smallCardShadow
+        )
 
-            // 徽章
-            if (BiliConfig.imageConfig.badgeEnable.left) {
-                drawBadge(
-                    lbadge,
-                    font,
-                    theme.subLeftBadge.fontColor,
-                    theme.subLeftBadge.bgColor,
-                    videoCardRect,
-                    Position.TOP_LEFT
-                )
-            }
-            if (BiliConfig.imageConfig.badgeEnable.right) {
-                drawBadge(
-                    rbadge,
-                    font,
-                    theme.subRightBadge.fontColor,
-                    theme.subRightBadge.bgColor,
-                    videoCardRect,
-                    Position.TOP_RIGHT
-                )
-            }
-
-            // 封面
-            val fallbackUrl = imgApi(cover, coverWidth.toInt(), quality.smallCardHeight)
-            val coverImg = getOrDownloadImageDefault(cover, fallbackUrl, CacheType.IMAGES)
-            val coverRRect = RRect.makeComplexXYWH(
-                videoCardRect.left, videoCardRect.top, coverWidth,
-                quality.smallCardHeight.toFloat(), cardBadgeArc
-            ).inflate(-1f) as RRect
-            drawImageRRect(coverImg, coverRRect)
-
-            val space = (videoCardRect.height - titleParagraph.height - descParagraph.height) / 3
-            val y = videoCardRect.top + space
-            titleParagraph.paint(
-                this,
-                quality.cardPadding * 1.5f + coverWidth,
-                y
+        // 4.2) 绘制徽章等
+        if (BiliConfig.imageConfig.badgeEnable.left) {
+            canvas.drawBadge(
+                lbadge,
+                font,
+                theme.subLeftBadge.fontColor,
+                theme.subLeftBadge.bgColor,
+                videoCardRect,
+                Position.TOP_LEFT
             )
-
-            descParagraph.paint(
-                this,
-                quality.cardPadding * 1.5f + coverWidth,
-                y + titleParagraph.height + space
+        }
+        if (BiliConfig.imageConfig.badgeEnable.right) {
+            canvas.drawBadge(
+                rbadge,
+                font,
+                theme.subRightBadge.fontColor,
+                theme.subRightBadge.bgColor,
+                videoCardRect,
+                Position.TOP_RIGHT
             )
+        }
 
-            if (duration != null) {
-                val durationTextLine = TextLine.make(duration, font.makeWithSize(quality.subTitleFontSize))
-                drawLabelCard(
-                    durationTextLine,
-                    coverRRect.left + quality.badgePadding * 2,
-                    coverRRect.bottom - durationTextLine.height - quality.badgePadding * 2,
-                    Paint().apply { color = Color.WHITE },
-                    Paint().apply {
-                        color = Color.BLACK
-                        alpha = 130
-                    }
-                )
-            }
+        // 4.3) 绘制封面图片：宽度 = desiredCoverWidth，高度 = scaledCoverHeight
+        val coverRRect = RRect.makeComplexXYWH(
+            videoCardRect.left,
+            videoCardRect.top,
+            desiredCoverWidth,
+            scaledCoverHeight,
+            cardBadgeArc
+        ).inflate(-1f) as RRect
+        canvas.drawImageRRect(coverImg, coverRRect)
+
+        // 4.4) 在右侧绘制标题/描述
+        val textX = coverRRect.right + quality.cardPadding
+
+        // 假设 titleParagraph + descParagraph 的总高度为 totalTextHeight
+        val totalTextHeight = titleParagraph.height + descParagraph.height
+        val space = (scaledCoverHeight - totalTextHeight) / 3
+        val textRegionTop = videoCardRect.top // 或者再往下偏移一些
+        val startY = textRegionTop + space
+
+        // 绘制标题
+        titleParagraph.paint(
+            canvas,
+            textX,
+            startY
+        )
+        // 绘制描述
+        descParagraph.paint(
+            canvas,
+            textX,
+            startY + titleParagraph.height + space
+        )
+
+        // 4.5) 如果有 duration，就在封面右下角再叠加一个小标签
+        if (duration != null) {
+            val durationTextLine = TextLine.make(duration, font.makeWithSize(quality.subTitleFontSize))
+            canvas.drawLabelCard(
+                durationTextLine,
+                coverRRect.left + quality.badgePadding * 2,
+                coverRRect.bottom - durationTextLine.height - quality.badgePadding * 2,
+                Paint().apply { color = Color.WHITE },
+                Paint().apply {
+                    color = Color.BLACK
+                    alpha = 130
+                }
+            )
         }
     }.makeImageSnapshot()
 }

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/DynamicService.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/DynamicService.kt
@@ -129,17 +129,17 @@ object DynamicService {
                 }else false
             }
             if (c == 0) appendLine("无")
-            //appendLine()
-            //appendLine("番剧: ")
-            //val cc = bangumi.count { (ssid, sub) ->
-            //    if (subject in sub.contacts) {
-            //        appendLine("${sub.title}@ss$ssid")
-            //        true
-            //    }else false
-            //}
-            //if (cc == 0) appendLine("无")
             appendLine()
-            //append("共 ${c + cc} 个订阅")
+            appendLine("番剧: ")
+            val cc = bangumi.count { (ssid, sub) ->
+                if (subject in sub.contacts) {
+                    appendLine("${sub.title}@ss$ssid")
+                    true
+                }else false
+            }
+            if (cc == 0) appendLine("无")
+            appendLine()
+            append("共 ${c + cc} 个订阅")
             append("共 ${c} 个订阅")
         }
     }

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/DynamicCheckTasker.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/DynamicCheckTasker.kt
@@ -25,7 +25,8 @@ object DynamicCheckTasker : BiliCheckTasker("Dynamic") {
     private val banType = listOf(
         DynamicType.DYNAMIC_TYPE_LIVE,
         DynamicType.DYNAMIC_TYPE_LIVE_RCMD,
-        //DynamicType.DYNAMIC_TYPE_PGC
+        //DynamicType.DYNAMIC_TYPE_PGC,
+        //DynamicType.DYNAMIC_TYPE_PGC_UNION
     )
 
     private const val capacity = 200
@@ -47,7 +48,7 @@ object DynamicCheckTasker : BiliCheckTasker("Dynamic") {
                     !historyDynamic.contains(it.did)
                 }.filter {
                     if (listenAllDynamicMode) true
-                    else if (it.type == DynamicType.DYNAMIC_TYPE_PGC)
+                    else if (it.type == DynamicType.DYNAMIC_TYPE_PGC || it.type == DynamicType.DYNAMIC_TYPE_PGC_UNION)
                         bangumi.contains(it.modules.moduleAuthor.mid)
                     else followingUsers.contains(it.modules.moduleAuthor.mid)
                 }.sortedBy {

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/DynamicMessageTasker.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/DynamicMessageTasker.kt
@@ -67,6 +67,7 @@ object DynamicMessageTasker : BiliTasker() {
             DYNAMIC_TYPE_AV -> modules.moduleDynamic.major?.archive?.title!!
             DYNAMIC_TYPE_MUSIC -> modules.moduleDynamic.major?.music?.title!!
             DYNAMIC_TYPE_PGC -> modules.moduleDynamic.major?.pgc?.title!!
+            DYNAMIC_TYPE_PGC_UNION -> modules.moduleDynamic.major?.pgc?.title!!
             DYNAMIC_TYPE_UGC_SEASON -> modules.moduleDynamic.major?.ugcSeason?.title!!
             DYNAMIC_TYPE_COMMON_VERTICAL,
             DYNAMIC_TYPE_COMMON_SQUARE -> modules.moduleDynamic.major?.common?.title!!
@@ -157,9 +158,10 @@ object DynamicMessageTasker : BiliTasker() {
                 )
             }
 
-            DYNAMIC_TYPE_PGC -> {
+            DYNAMIC_TYPE_PGC,
+            DYNAMIC_TYPE_PGC_UNION -> {
                 listOf(
-                    DynamicMessage.Link(DYNAMIC_TYPE_PGC.text, EPISODE_LINK(this.modules.moduleDynamic.major?.pgc?.epid!!.toString())),
+                    DynamicMessage.Link(type.text, EPISODE_LINK(this.modules.moduleDynamic.major?.pgc?.epid!!.toString())),
                     DynamicMessage.Link("动态", DYNAMIC_LINK(did))
                 )
             }

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/SendTasker.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/SendTasker.kt
@@ -221,7 +221,8 @@ object SendTasker : BiliTasker() {
             DynamicType.DYNAMIC_TYPE_FORWARD -> DynamicFilterType.FORWARD
             DynamicType.DYNAMIC_TYPE_AV,
             DynamicType.DYNAMIC_TYPE_UGC_SEASON,
-            DynamicType.DYNAMIC_TYPE_PGC -> DynamicFilterType.VIDEO
+            DynamicType.DYNAMIC_TYPE_PGC,
+            DynamicType.DYNAMIC_TYPE_PGC_UNION -> DynamicFilterType.VIDEO
 
             DynamicType.DYNAMIC_TYPE_MUSIC -> DynamicFilterType.MUSIC
             DynamicType.DYNAMIC_TYPE_ARTICLE -> DynamicFilterType.ARTICLE
@@ -232,7 +233,7 @@ object SendTasker : BiliTasker() {
 
     private fun getDynamicContactList(mid: Long, content: String, type: DynamicType): MutableSet<String>? {
             return try {
-                if (type == DynamicType.DYNAMIC_TYPE_PGC) {
+                if (type == DynamicType.DYNAMIC_TYPE_PGC || type == DynamicType.DYNAMIC_TYPE_PGC_UNION) {
                     return bangumi[mid]?.contacts
                 }
 

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/utils/General.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/utils/General.kt
@@ -127,6 +127,7 @@ val DynamicItem.link: String
         DYNAMIC_TYPE_LIVE -> "https://live.bilibili.com/${modules.moduleDynamic.major?.live?.id}"
         DYNAMIC_TYPE_LIVE_RCMD -> "https://live.bilibili.com/${modules.moduleDynamic.major?.live?.id}"
         DYNAMIC_TYPE_PGC -> "https://www.bilibili.com/bangumi/play/ep${modules.moduleDynamic.major?.pgc?.epid}"
+        DYNAMIC_TYPE_PGC_UNION -> "https://www.bilibili.com/bangumi/play/ep${modules.moduleDynamic.major?.pgc?.epid}"
         DYNAMIC_TYPE_UGC_SEASON -> "https://www.bilibili.com/video/av${modules.moduleDynamic.major?.ugcSeason?.aid}"
         DYNAMIC_TYPE_NONE -> ""
     }


### PR DESCRIPTION
## fix:未开播主播直播间链接解析时出错
发送未开播直播间地址时，返回的json中`up_session`的值为`"up_session": ""`
而 `LiveRoomDetail `数据类中的定义为
```
@Serializable
data class LiveRoomDetail(
    @SerialName("up_session")
    val upSession: Long? = null,  // 这里期望的是 Long?
)
```
改为将其按照`String?`进行解析。
或者由于此成员实际上并未使用，直接注释掉也可以。
close #109

## feat:支持`DYNAMIC_TYPE_PGC_UNION`类型的番剧订阅
之前的追番只追了`DYNAMIC_TYPE_PGC`，但是现在番剧基本都是`DYNAMIC_TYPE_PGC_UNION`了导致追番没有效果，现在添加了对`DYNAMIC_TYPE_PGC_UNION`类型番剧的支持

## fix:没有正确区分BASE_PGC与BASE_PGC_MEDIA的链接
之前的`BASE_PGC_MEDIA`在被`PGC_LINK`调用时也会使用`"$BASE_PGC/$id"`而非`"$BASE_PGC_MEDIA/$id"`解析，导致返回的地址错误

## fix:充电抽奖解析错误
与未开播直播间的错误类似，`is_upower_active`被定义为了`Boolean?`导致解析错误。
由于这个成员并没有被实际使用，直接注释掉了。

## feat:番剧解析时动态封面高度
原本的`drawSmallCard`方法固定使用16:10比例，在显示竖直图片例如部分番剧封面时会导致图片被不保留比例地压缩：
![image](https://github.com/user-attachments/assets/c686b92a-1ca5-45bf-aeaf-06adda6f1ab9)
将`drawSmallCard`修改为了固定宽度后动态高度，并相应地将右侧的标题与描述间隔划分在1/3与2/3处
![image](https://github.com/user-attachments/assets/92a341f5-281f-4844-ac88-b9e5d8851fbb)

对于原本16:10的情况，显示效果基本没有变化（直播间解析也是使用`drawSmallCard`方法进行的）：
![image](https://github.com/user-attachments/assets/8728e816-7915-417c-8bed-15bcc60e7925)
（这里也是修复后可以正常显示未开播直播间的演示）