### PR TITLE
优化和修复：链接解析和用户体验改进

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Vtuber 字幕组及粉丝群如需要使用可通过群联系我, 使用我搭�
 #   translateEnable: 翻译开关
 #   proxyEnable: 代理开关
 #   cacheClearEnable: 缓存清理开关
+#   showLoadingMessage: 是否显示"加载中"提示消息
 enableConfig:
   drawEnable: true
   notifyEnable: true
@@ -468,6 +469,7 @@ enableConfig:
   translateEnable: false
   proxyEnable: false
   cacheClearEnable: true
+  showLoadingMessage: true
 
 # 账号配置:
 #   cookie: BiliBili的cookie, 可使用 /bili login 自动获取

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt
@@ -280,7 +280,7 @@ data class LinkResolveConfig(
     val triggerMode: TriggerMode = TriggerMode.At,
     val returnLink: Boolean = false,
     val regex: List<String> = listOf(
-        """(www\.bilibili\.com/video/((BV[0-9A-z]{10})|(av\d{1,10})))|^(BV[0-9A-z]{10})|^(av\d{1,10})""",
+        """(www\.bilibili\.com/video/((BV[0-9A-z]{10})|(av\d{1,20})))|^(BV[0-9A-z]{10})|^(av\d{1,20})""",
         """(www\.bilibili\.com/read/cv\d{1,10})|^(cv\d{1,10})|(www\.bilibili\.com/read/mobile/\d{1,10})""",
         """((www|m)\.bilibili\.com/bangumi/(play|media)/(ss|ep|md)\d+)|^((ss|ep|md)\d+)""",
         """([tm]\.bilibili\.com/(dynamic/)?\d+)|(www\.bilibili\.com/opus/\d+)""",

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt
@@ -149,6 +149,7 @@ data class EnableConfig(
     var translateEnable: Boolean = false,
     val proxyEnable: Boolean = false,
     val cacheClearEnable: Boolean = true,
+    val showLoadingMessage: Boolean = true,
 )
 
 @Serializable

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/command/DynamicCommand.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/command/DynamicCommand.kt
@@ -37,6 +37,7 @@ object DynamicCommand : CompositeCommand(
 ) {
 
     private val admin by BiliConfig::admin
+    private val showLoadingMessage get() = BiliConfig.enableConfig.showLoadingMessage
 
     @SubCommand("h", "help", "帮助", "menu")
     suspend fun CommandSender.help() {
@@ -187,7 +188,7 @@ object DynamicCommand : CompositeCommand(
 
     @SubCommand("templateList", "tl", "模板列表")
     suspend fun CommandSenderOnMessage<*>.templateList(type: String = "d") {
-        val ms = subject?.sendMessage("加载中...")
+        val ms = if (showLoadingMessage) subject?.sendMessage("加载中...") else null
         TemplateService.listTemplate(type, Contact())
         ms?.recall()
     }
@@ -265,7 +266,7 @@ object DynamicCommand : CompositeCommand(
 
     @SubCommand("search", "s", "搜索")
     suspend fun CommandSenderOnMessage<*>.search(did: String) {
-        val msg = sendMessage("加载中...")
+        val msg = if (showLoadingMessage) sendMessage("加载中...") else null
         try {
             val detail = biliClient.getDynamicDetail(did)
             if (detail != null) {
@@ -290,7 +291,7 @@ object DynamicCommand : CompositeCommand(
 
     @SubCommand("new", "最新动态")
     suspend fun CommandSenderOnMessage<*>.new(user: String, count: Int = 1) {
-        val msg = sendMessage("加载中...")
+        val msg = if (showLoadingMessage) sendMessage("加载中...") else null
         matchUser(user) {
             try {
                 val list = biliClient.getUserNewDynamic(it)?.items?.subList(0, count)
@@ -308,7 +309,7 @@ object DynamicCommand : CompositeCommand(
 
     @SubCommand("video", "最新视频")
     suspend fun CommandSenderOnMessage<*>.newVideo(user: String) {
-        val msg = sendMessage("加载中...")
+        val msg = if (showLoadingMessage) sendMessage("加载中...") else null
         matchUser(user) {
             try {
                 biliClient.searchUserVideo(it)?.list?.vlist?.run {

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/BascLink.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/data/BascLink.kt
@@ -16,7 +16,7 @@ const val BASE_PGC = "https://www.bilibili.com/bangumi/play"
 const val BASE_PGC_MEDIA = "https://www.bilibili.com/bangumi/media"
 const val BASE_LIVE = "https://live.bilibili.com"
 const val BASE_SPACE = "https://space.bilibili.com"
-const val BASE_SHORT = "b23.tv"
+const val BASE_SHORT = "https://b23.tv"
 
 val toShortLink: Boolean by lazy { BiliConfig.pushConfig.toShortLink }
 

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
@@ -11,14 +11,19 @@ import java.time.Instant
 
 private val regex = BiliConfig.linkResolveConfig.reg
 
-fun matchingRegular(content: String): LinkType? {
+fun matchingRegular(content: String): ResolvedLinkInfo? {
     return if (regex.any { it.find(content) != null }) {
         logger.info("开始解析链接 -> $content")
         matchingInternalRegular(content)
     } else null
 }
 
-fun matchingInternalRegular(content: String): LinkType? {
+data class ResolvedLinkInfo(val type: LinkType, val id: String) : ResolveLink {
+    override suspend fun drawGeneral(): String? = type.drawGeneral(id)
+    override suspend fun getLink(): String = type.getLink(id)
+}
+
+fun matchingInternalRegular(content: String): ResolvedLinkInfo? {
     var matchResult: MatchResult? = null
     var type: LinkType? = null
 
@@ -33,8 +38,7 @@ fun matchingInternalRegular(content: String): LinkType? {
         if (matchResult != null) break
     }
     return if (matchResult != null && type != null) {
-        type.id = matchResult.destructured.component1()
-        type
+        ResolvedLinkInfo(type, matchResult.destructured.component1())
     }else {
         logger.warning("未匹配到链接! -> $content")
         null
@@ -53,93 +57,88 @@ interface ResolveLink {
     suspend fun getLink(): String
 }
 
-enum class LinkType(val regex: List<Regex>, var id: String? = null): ResolveLink {
+enum class LinkType(val regex: List<Regex>) {
     VideoLink(listOf(
         """(?:www\.bilibili\.com/video/)?((?:BV[0-9A-z]{10})|(?:av\d{1,20}))""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            return biliClient.getVideoDetail(id!!)?.run {
-                drawGeneral(id!!, "视频", pubdate.formatTime, toDrawAuthorData(), toDrawData().drawGeneral(true))
-            }
-        }
-
-        override suspend fun getLink(): String = VIDEO_LINK(id!!)
-
-    },
+    )),
     Article(listOf(
         """(?:www\.bilibili\.com/read/)?cv(\d{1,10})""".toRegex(),
         """(?:www\.bilibili\.com/read/mobile/)(\d{1,10})""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            return biliClient.getArticleDetail("cv$id")?.run {
-                drawGeneral(id!!, "专栏", time.formatTime, author, toDrawData().drawGeneral())
-            }
-        }
-
-        override suspend fun getLink(): String = ARTICLE_LINK(id!!)
-    },
+    )),
     Dynamic(listOf(
         """[tm]\.bilibili\.com/(?:dynamic/)?(\d+)""".toRegex(),
         """(?:www|m)\.bilibili\.com/opus/(\d+)""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            val color = Color.makeRGB(BiliConfig.imageConfig.defaultColor)
-            return biliClient.getDynamicDetail(id!!)?.run {
-                val dynamic = drawDynamic(color)
-                val img = makeCardBg(dynamic.height, listOf(color)) {
-                    it.drawImage(dynamic, 0f, 0f)
-                }
-                cacheImage(img, "$idStr.png", CacheType.DRAW_SEARCH)
-            }
-        }
-
-        override suspend fun getLink(): String = DYNAMIC_LINK(id!!)
-    },
+    )),
     Live(listOf(
         """live\.bilibili\.com/(?:h5/)?(\d+)""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            val room = biliClient.getLiveDetail(id!!) ?: return null
-            val author = biliClient.userInfo(room.uid)?.toDrawAuthorData() ?: return null
-            val data = room.toDrawData().drawGeneral()
-            return drawGeneral(id!!, "直播", Instant.now().epochSecond.formatTime, author, data)
-        }
-
-        override suspend fun getLink(): String = LIVE_LINK(id!!)
-    },
+    )),
     User(listOf(
         """space\.bilibili\.com/(\d+)""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            val author = biliClient.userInfo(id!!.toLong())?.toDrawAuthorData() ?: return null
-            return drawGeneral(id!!, "用户", Instant.now().epochSecond.formatTime, author, null)
-        }
-
-        override suspend fun getLink(): String = SPACE_LINK(id!!)
-    },
+    )),
     Pgc(listOf(
         """(?:(?:www|m)\.bilibili\.com/bangumi/(?:play|media)/)?((?:ss|ep|md)\d+)""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            val info = biliClient.getPcgInfo(id!!) ?: return null
-            val author = info.toPgcAuthor() ?: return null
-            val data = info.toPgc()?.drawSmall()
-            return drawGeneral(id!!, "番剧", Instant.now().epochSecond.formatTime, author, data)
-        }
-
-        override suspend fun getLink(): String = PGC_LINK(id!!)
-    },
+    )),
     ShortLink(listOf(
         """(?:b23\.tv|bili2233\.cn)\\?/([0-9A-z]+)""".toRegex()
-    )) {
-        override suspend fun drawGeneral(): String? {
-            val link = biliClient.redirect("https://b23.tv/$id")
-            return if (link != null) {
-                matchingInternalRegular(link)?.drawGeneral()
-            }else null
-        }
+    ));
 
-        override suspend fun getLink(): String = "$BASE_SHORT/$id"
+    suspend fun drawGeneral(id: String): String? {
+        return when (this) {
+            VideoLink -> {
+                biliClient.getVideoDetail(id)?.run {
+                    drawGeneral(id, "视频", pubdate.formatTime, toDrawAuthorData(), toDrawData().drawGeneral(true))
+                }
+            }
+            Article -> {
+                biliClient.getArticleDetail("cv$id")?.run {
+                    drawGeneral(id, "专栏", time.formatTime, author, toDrawData().drawGeneral())
+                }
+            }
+            Dynamic -> {
+                val color = Color.makeRGB(BiliConfig.imageConfig.defaultColor)
+                biliClient.getDynamicDetail(id)?.run {
+                    val dynamic = drawDynamic(color)
+                    val img = makeCardBg(dynamic.height, listOf(color)) {
+                        it.drawImage(dynamic, 0f, 0f)
+                    }
+                    cacheImage(img, "$idStr.png", CacheType.DRAW_SEARCH)
+                }
+            }
+            Live -> {
+                val room = biliClient.getLiveDetail(id) ?: return null
+                val author = biliClient.userInfo(room.uid)?.toDrawAuthorData() ?: return null
+                val data = room.toDrawData().drawGeneral()
+                drawGeneral(id, "直播", Instant.now().epochSecond.formatTime, author, data)
+            }
+            User -> {
+                val author = biliClient.userInfo(id.toLong())?.toDrawAuthorData() ?: return null
+                drawGeneral(id, "用户", Instant.now().epochSecond.formatTime, author, null)
+            }
+            Pgc -> {
+                val info = biliClient.getPcgInfo(id) ?: return null
+                val author = info.toPgcAuthor() ?: return null
+                val data = info.toPgc()?.drawSmall()
+                drawGeneral(id, "番剧", Instant.now().epochSecond.formatTime, author, data)
+            }
+            ShortLink -> {
+                val link = biliClient.redirect("https://b23.tv/$id")
+                if (link != null) {
+                    matchingInternalRegular(link)?.drawGeneral()
+                } else null
+            }
+        }
+    }
+
+    suspend fun getLink(id: String): String {
+        return when (this) {
+            VideoLink -> VIDEO_LINK(id)
+            Article -> ARTICLE_LINK(id)
+            Dynamic -> DYNAMIC_LINK(id)
+            Live -> LIVE_LINK(id)
+            User -> SPACE_LINK(id)
+            Pgc -> PGC_LINK(id)
+            ShortLink -> "$BASE_SHORT/$id"
+        }
     }
 }
 

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
@@ -55,7 +55,7 @@ interface ResolveLink {
 
 enum class LinkType(val regex: List<Regex>, var id: String? = null): ResolveLink {
     VideoLink(listOf(
-        """(?:www\.bilibili\.com/video/)?((?:BV[0-9A-z]{10})|(?:av\d{1,10}))""".toRegex()
+        """(?:www\.bilibili\.com/video/)?((?:BV[0-9A-z]{10})|(?:av\d{1,20}))""".toRegex()
     )) {
         override suspend fun drawGeneral(): String? {
             return biliClient.getVideoDetail(id!!)?.run {

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/ListenerTasker.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/ListenerTasker.kt
@@ -17,6 +17,7 @@ object ListenerTasker : BiliTasker() {
 
     private val triggerMode = BiliConfig.linkResolveConfig.triggerMode
     private val returnLink = BiliConfig.linkResolveConfig.returnLink
+    private val showLoadingMessage = BiliConfig.enableConfig.showLoadingMessage
 
     override suspend fun main() {
         globalEventChannel().subscribeAlways<BotLeaveEvent> {
@@ -45,16 +46,16 @@ object ListenerTasker : BiliTasker() {
                 val msg = message.filter { it !is At && it !is Image }.toMessageChain().content.trim()
                 val type = matchingRegular(msg)
                 if (type != null) {
-                    val ms = subject.sendMessage("加载中...")
+                    val ms = if (showLoadingMessage) subject.sendMessage("加载中...") else null
                     val img = type.drawGeneral()
                     if (img == null) {
-                        ms.recall()
+                        ms?.recall()
                         subject.sendMessage("解析失败")
                         return@subscribeAlways
                     }
                     val imgMsg = subject.uploadImage(img, CacheType.DRAW_SEARCH)
                     if (imgMsg == null) {
-                        ms.recall()
+                        ms?.recall()
                         subject.sendMessage("图片上传失败")
                         return@subscribeAlways
                     }
@@ -62,7 +63,7 @@ object ListenerTasker : BiliTasker() {
                         + imgMsg
                         if (returnLink) + PlainText(type.getLink())
                     })
-                    ms.recall()
+                    ms?.recall()
                 }
             }
         }


### PR DESCRIPTION
## 概述

包含4个修复和功能改进，主要集中在链接解析系统的bug修复和用户体验的改进。

## 修改内容

### 1. 修复 AV 号链接解析长度限制问题 
**Commit:** `6314183`

**问题：** 无法解析 av 数字部分长度超过10位的视频链接

**示例问题链接：** `https://www.bilibili.com/video/av114471515259108`

**修复内容：**
- 将正则表达式中的 `av\d{1,10}` 修改为 `av\d{1,20}`
- 同时修复了 `BiliConfig.kt` 和 `ResolveLinkService.kt` 中的相关正则表达式
- 现在支持最长20位的 AV 号，能够处理更大范围的 B 站视频 ID

**文件修改：**
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt`
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt`

### 2. 修复链接解析并发竞态条件问题 
**Commit:** `0731f83`

**问题：** 当同时处理多个视频链接时，所有请求都会返回最后一个视频的链接地址

修复前：
![e537b1f110e483c029cdaeb166f96d2c](https://github.com/user-attachments/assets/68398efa-a7ac-4e2e-ad7e-ed09f2686fed)
（前两个视频下方附加的链接实际上是第三个视频的链接，第三个视频因为自己是短链接，所以原样输出了，反而没有显示自己的bv形式链接）
修复后：
![f92893d0bbac28a065c6ab4e95f7ecb7](https://github.com/user-attachments/assets/2ac54392-5b4d-48c9-ba7b-546cf1b73e7f)
（每个视频显示各自的链接，互不影响）

**根本原因：** `LinkType` 枚举中的 `id` 字段是类级别的静态变量，多个并发请求会互相覆盖

**解决方案：**
- 创建 `ResolvedLinkInfo` 数据类，每个请求都有独立的实例
- 重构 `LinkType` 枚举，移除可变状态，将方法改为接受 `id` 参数
- 确保线程安全，避免并发请求之间的状态共享

**技术细节：**
- 将 `enum class LinkType(..., var id: String? = null): ResolveLink` 
- 改为 `enum class LinkType(...)` + `data class ResolvedLinkInfo(...): ResolveLink`
- 所有 `drawGeneral()` 和 `getLink()` 方法改为参数化

**文件修改：**
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt` (大幅重构)

### 3. 修复短链接协议问题 
**Commit:** `3ae4c3b`

**问题：** `BASE_SHORT` 缺少 `https://` 前缀，导致在手机QQ等特定环境下打开链接异常

**修复内容：**
- 将 `const val BASE_SHORT = "b23.tv"` 
- 修改为 `const val BASE_SHORT = "https://b23.tv"`

**文件修改：**
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/data/BascLink.kt`

### 4. 新增功能：可选的"加载中"提示消息 
**Commit:** `e6274d2`

**功能：** 允许用户关闭"加载中"提示消息，避免"已撤回一条消息"的系统提示

**用户痛点：** 部分用户不喜欢看到撤回消息后留下的系统提示

**实现方案：**
- 在 `EnableConfig` 中新增 `showLoadingMessage: Boolean = true` 配置项
- 修改所有相关代码，根据配置决定是否显示加载提示
- 保持向后兼容，默认开启（保持原有行为）

**影响范围：**
- 链接解析功能（`ListenerTasker.kt`）
- 命令系统中的 `templateList`、`search`、`new`、`newVideo` 等命令（`DynamicCommand.kt`）

**配置使用：**
```yaml
enableConfig:
  showLoadingMessage: false  # 关闭所有"加载中"提示
```

**文件修改：**
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/BiliConfig.kt`
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/tasker/ListenerTasker.kt`
- `src/main/kotlin/top/colter/mirai/plugin/bilibili/command/DynamicCommand.kt`
- `README.md` (更新配置文档)

## 测试验证

- ✅ 编译测试通过
- ✅ 长 AV 号链接解析正常
- ✅ 并发链接解析返回正确结果
- ✅ 短链接在各平台正常打开
- ✅ 加载提示配置功能正常工作

## 文档更新

- 更新了 `README.md` 中关于 `enableConfig.showLoadingMessage` 的配置说明
- 添加了配置示例和使用说明

## 向后兼容性

- ✅ 所有新配置项都有合理的默认值
- ✅ 现有用户的配置文件无需修改即可正常工作
- ✅ 功能行为默认保持与之前版本一致