### PR TITLE
fix: 解析优先级

### DIFF
--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/service/ResolveLinkService.kt
@@ -27,7 +27,11 @@ fun matchingInternalRegular(content: String): ResolvedLinkInfo? {
     var matchResult: MatchResult? = null
     var type: LinkType? = null
 
-    for (linkType in LinkType.values()) {
+    // 定义优先级顺序：短链接优先，其他保持原顺序
+    val prioritizedTypes = listOf(LinkType.ShortLink) + 
+        LinkType.values().filter { it != LinkType.ShortLink }
+
+    for (linkType in prioritizedTypes) {
         for (regex in linkType.regex) {
             matchResult = regex.find(content)
             if (matchResult != null) {


### PR DESCRIPTION
## 概述

目前的解析逻辑顺序按照 LinkType.values() 的顺序遍历所有类型，并且一旦找到匹配就立即返回。
而在 LinkType 枚举中，VideoLink 排在第一位，ShortLink 排在最后。
对于json卡片类型的消息，里面的preview等部分会含有干扰内容，当消息中包含 av88 这样的内容时，会优先匹配到 VideoLink 而不是 ShortLink。

例：
```
[CQ:json,data={\"app\":\"com.tencent.tuwen.lua\"&#44;\"bizsrc\":\"qqconnect.sdkshare\"&#44;\"config\":{\"ctime\":1753263666&#44;\"forward\":1&#44;\"token\":\"8e6570b666cfbde0e4754b81e35ccacb\"&#44;\"type\":\"normal\"}&#44;\"extra\":{\"app_type\":1&#44;\"appid\":100951776&#44;\"msg_seq\":7530210091575866726&#44;\"uin\":315666610}&#44;\"meta\":{\"news\":{\"app_type\":1&#44;\"appid\":100951776&#44;\"ctime\":1753263666&#44;\"desc\":\"Shiravune白舟_官方\"&#44;\"jumpUrl\":\"https://b23.tv/1cWRXBE?share_medium=android&amp;share_source=qq&amp;bbid=XY33CC53F01C05F933A91481382C5F86272F5&amp;ts=1753263656974\"&#44;\"preview\":\"https://qq.ugcimg.cn/v1/eup3cer1te1llj9k8uktpjs7lpj3js3sol7c0kngp5rlo9n8rcmmrgl74aqce5d0iav88kjbfjpf1lkn4pn62tma7nkufd7b1hmhh64fg6sedju6jjpd8o8opdqd1lmc2burcl55el0ek3lcftblfbprl22vh5d2h16gcn2b8s5gq43rhhl4sevvcp4cljqgnidccsjbad0p0/e9vf2tsqr6j29hl2kodb3vahlc\"&#44;\"tag\":\"哔哩哔哩\"&#44;\"tagIcon\":\"https://open.gtimg.cn/open/app_icon/00/95/17/76/100951776_100_m.png?t=1753252958\"&#44;\"title\":\"Shiravune预定将于7月24日公布新作消息，敬请期待！…\"&#44;\"uin\":315666610}}&#44;\"prompt\":\"&#91;分享&#93;Shiravune预定将于7月24日公布新作消息，敬请期待！…\"&#44;\"ver\":\"0.0.0.1\"&#44;\"view\":\"news\"}]
```

## 修改内容
在 matchingInternalRegular 中优先处理短链接的解析。
修改前：
<img width="1100" height="1295" alt="PixPin_2025-07-26_11-14-32" src="https://github.com/user-attachments/assets/6f5acdcf-4a11-4997-8f6f-edba1697a71a" />
修改后：
<img width="1082" height="1264" alt="PixPin_2025-07-26_11-14-55" src="https://github.com/user-attachments/assets/fb0b7a7f-f61d-40ad-be84-24e2dd9b4cb9" />