### PR TITLE
fix(draw): 避免关闭翻译时将译文并入正文排版

### DIFF
--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicModuleDraw.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicModuleDraw.kt
@@ -266,16 +266,14 @@ suspend fun ModuleDynamic.ContentDesc.drawGeneral(): Image {
         textStyle = titleTextStyle
     }
 
-    val traCutLineNode = ModuleDynamic.ContentDesc.RichTextNode(
-        "RICH_TEXT_NODE_TYPE_TEXT",
-        BiliConfig.translateConfig.cutLine,
-        BiliConfig.translateConfig.cutLine
+    val nodes = buildContentDescRenderNodes(
+        richTextNodes = richTextNodes,
+        translation = trans(text),
+        cutLine = BiliConfig.translateConfig.cutLine,
     )
 
-    val tra = trans(text)
-
     val textParagraph =
-        ParagraphBuilder(paragraphStyle, FontUtils.fonts).addText("$text${traCutLineNode.text}$tra").build()
+        ParagraphBuilder(paragraphStyle, FontUtils.fonts).addText(buildContentDescMeasureText(nodes)).build()
             .layout(cardContentRect.width)
 
     val textCardHeight = (quality.contentFontSize + quality.lineSpace * 2) * (textParagraph.lineNumber + 2)
@@ -292,15 +290,6 @@ suspend fun ModuleDynamic.ContentDesc.drawGeneral(): Image {
 
     return Surface.makeRasterN32Premul(cardRect.width.toInt(), textCardHeight.toInt()).apply {
         canvas.apply {
-            val nodes = if (tra != null) {
-                richTextNodes.plus(traCutLineNode).plus(
-                    ModuleDynamic.ContentDesc.RichTextNode(
-                        "RICH_TEXT_NODE_TYPE_TEXT", tra, tra
-                    )
-                )
-            } else {
-                richTextNodes
-            }
             nodes.forEach {
                 when (it.type) {
                     "RICH_TEXT_NODE_TYPE_TEXT" -> {
@@ -359,6 +348,34 @@ suspend fun ModuleDynamic.ContentDesc.drawGeneral(): Image {
             }
         }
     }.makeImageSnapshot(IRect.makeXYWH(0, 0, cardRect.width.toInt(), ceil(y + quality.lineSpace * 2).toInt()))!!
+}
+
+internal fun buildContentDescRenderNodes(
+    richTextNodes: List<ModuleDynamic.ContentDesc.RichTextNode>,
+    translation: String?,
+    cutLine: String,
+): List<ModuleDynamic.ContentDesc.RichTextNode> {
+    if (translation.isNullOrBlank()) {
+        return richTextNodes
+    }
+
+    return richTextNodes +
+        ModuleDynamic.ContentDesc.RichTextNode(
+            type = "RICH_TEXT_NODE_TYPE_TEXT",
+            origText = cutLine,
+            text = cutLine,
+        ) +
+        ModuleDynamic.ContentDesc.RichTextNode(
+            type = "RICH_TEXT_NODE_TYPE_TEXT",
+            origText = translation,
+            text = translation,
+        )
+}
+
+internal fun buildContentDescMeasureText(
+    nodes: List<ModuleDynamic.ContentDesc.RichTextNode>
+): String {
+    return nodes.joinToString(separator = "") { it.text }
 }
 
 sealed class RichText(


### PR DESCRIPTION
统一内容描述的测量与绘制节点来源，仅在翻译结果存在时追加 cutLine 和译文节点，避免翻译关闭或无结果时仍影响正文渲染和高度计算。
因为没有安装Mirai环境，没有实际编译以及正式环境测试，所以下面的示例是理想状态下的效果（取自我的迁移版本）
修复前：
![4da7ced95deb0e73ef660a2b1c1f6875](https://github.com/user-attachments/assets/ef91d9ed-f1db-47c2-979d-ef9cd335f05e)
修复后：
![0c023579f3f67b8422cbde880fef1539](https://github.com/user-attachments/assets/ef45753e-ca71-4527-8ee1-e5b02e9cb565)
问题原因：
1. 高度测量时，直接拿字符串去算：
kotlin
"$text${traCutLineNode.text}$tra"

2. 真正绘制时，只有 tra != null 才把 cutLine 和译文节点塞进 nodes。

这会导致一个典型的“分叉”：

- 测量链路默认把 cutLine 算进去了
- 绘制链路不一定真的画 cutLine
- 结果就是配置项虽然没真正启动翻译，cutLine 还是可能先进入排版测量，造成空白、行数、卡片高度判断偏大一类副作用