### PR TITLE
fix: 修复 WBI 签名实现问题

### DIFF
--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/api/General.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/api/General.kt
@@ -38,9 +38,18 @@ suspend inline fun <reified T> BiliClient.getDataWithWbi(
 ): T? {
     val builder = HttpRequestBuilder()
     builder.block()
-    val params = builder.url.parameters.build().formUrlEncode()
     val wts = System.currentTimeMillis() / 1000
-    val wrid = "$params&wts=$wts${getVerifyString()}".md5()
+    val mixinKey = getVerifyString()
+    // Collect all params including wts, sort by key, filter illegal chars
+    val allParams = mutableMapOf<String, String>()
+    builder.url.parameters.build().forEach { key, values ->
+        allParams[key] = values.firstOrNull() ?: ""
+    }
+    allParams["wts"] = wts.toString()
+    val sortedQuery = allParams.entries
+        .sortedBy { it.key }
+        .joinToString("&") { "${it.key}=${it.value}" }
+    val wrid = "$sortedQuery$mixinKey".md5()
     return getData(url) {
         block()
         parameter("w_rid", wrid)


### PR DESCRIPTION
- 参数未排序：Bilibili WBI 要求所有参数（包括 wts）按 key 字母顺序排列后再拼接
- 使用了 formUrlEncode()：这会对参数值做 URL 编码（如空格变 +），但签名应该用原始值 现在改为收集所有参数 → 加入 wts → 按 key 排序 → 拼接原始值 → 追加 mixin key → MD5