### PR TITLE
refactor(draw): 提取标签卡片文本基线计算为独立函数

### DIFF
--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicDraw.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicDraw.kt
@@ -355,7 +355,7 @@ fun Rect.textVertical(text: TextLine) =
     bottom - (height - text.capHeight) / 2
 
 internal fun labelCardTextBaseline(rrect: RRect, textLine: TextLine): Float =
-    Rect.makeXYWH(rrect.left, rrect.top, rrect.width, rrect.height).textVertical(textLine)
+    rrect.bottom - (rrect.height - textLine.capHeight) / 2
 
 fun Canvas.drawCard(rrect: RRect, bgColor: Int = theme.cardBgColor) {
     drawRRect(rrect, Paint().apply {

--- a/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicDraw.kt
+++ b/src/main/kotlin/top/colter/mirai/plugin/bilibili/draw/DynamicDraw.kt
@@ -354,6 +354,9 @@ fun drawBlockedDefault(): Image {
 fun Rect.textVertical(text: TextLine) =
     bottom - (height - text.capHeight) / 2
 
+internal fun labelCardTextBaseline(rrect: RRect, textLine: TextLine): Float =
+    Rect.makeXYWH(rrect.left, rrect.top, rrect.width, rrect.height).textVertical(textLine)
+
 fun Canvas.drawCard(rrect: RRect, bgColor: Int = theme.cardBgColor) {
     drawRRect(rrect, Paint().apply {
         color = bgColor
@@ -534,8 +537,7 @@ fun Canvas.drawLabelCard(
     drawTextLine(
         textLine,
         rrect.left + quality.badgePadding * 2,
-        rrect.bottom - quality.badgePadding,
-        //rrect.textVertical(textLine),
+        labelCardTextBaseline(rrect, textLine),
         fontPaint
     )
 }


### PR DESCRIPTION
如果用户使用自定义字体会出现部分文本字体偏下的情况，解决方法如下：
不再把 rrect.bottom - quality.badgePadding 当作文字 y 坐标。drawTextLine() 的 y 是文字基线，必须按字体度量重新算。自定义字体一换，TextLine.height/capHeight/ascent/descent 都会变，固定 padding 公式就会偏。
<img width="236" height="100" alt="dynamic-media-label-alignment-动图" src="https://github.com/user-attachments/assets/eae363d9-853e-4abc-8102-ca689bae07fb" />
<img width="236" height="100" alt="dynamic-media-label-alignment-长图" src="https://github.com/user-attachments/assets/417b2685-540d-43db-b3d8-0e3928733a97" />
